### PR TITLE
improvement(git-gateway): included store_id on create git-gateway ins…

### DIFF
--- a/api/GitGateway.js
+++ b/api/GitGateway.js
@@ -32,9 +32,10 @@ class GitGateway {
       }
       const data = {
         uuid: uuid(),
+        store_id: payload.gotrue.store_id,
         config: {
           jwt: {
-            secret: process.env.STOREFRONT_CI_OPERATOR_TOKEN
+            secret: process.env.STOREFRONT_CI_JWT_TOKEN
           },
           github: {
             access_token: process.env.STOREFRONT_CI_GITHUB_TOKEN,


### PR DESCRIPTION
Foi ajustado para enviar o store_id na criação da instancia do git-gateway. 
Outra alteração foi o envio do `STOREFRONT_CI_JWT_TOKEN` no atributo jwt da config da instância. Com isso é necessário inserir este cara nas variáveis de ambiente. O STOREFRONT_CI_JWT_TOKEN deve ser o mesmo contido em `GITGATEWAY_JWT_SECRET` das variáveis do git-gateway.

[issue 6](https://github.com/ecomplus/storefront-ci/issues/6)